### PR TITLE
issue fixes #1 Capture and CaptureWithCGo leak file descriptors on OSX

### DIFF
--- a/capture_test.go
+++ b/capture_test.go
@@ -1,13 +1,29 @@
 package osutil
 
 import (
+	"syscall"
 	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCapture(t *testing.T) {
-	testCapture(t)
+	var limit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit)
+	assert.Nil(t, err)
+	//fmt.Fprintf(os.Stderr, "%v file descriptors out of a maximum of %v available\n", limit.Cur, limit.Max) 
+	// use limit.Cur or something like 1024
+	for i :=0; i <= int(limit.Cur); i++ {
+		testCapture(t)
+	}
 }
 
 func TestCaptureWithCGo(t *testing.T) {
-	testCaptureWithCGo(t)
+	var limit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit)
+	assert.Nil(t, err)
+	//fmt.Fprintf(os.Stderr, "%v file descriptors out of a maximum of %v available\n", limit.Cur, limit.Max) 
+	// use limit.Cur or something like 512
+	for i:=0; i <= int(limit.Cur); i++ {
+		testCaptureWithCGo(t)
+	}
 }


### PR DESCRIPTION
symptoms after open file descriptors exhausted:

--- FAIL: TestCapture (0.03s)

	Error:      	Expected nil, but got: &os.SyscallError{Syscall:"pipe", Err:0x18}
        Error Trace:    capture_wrapper.go:26

	Error:      	Expected nil, but got: &errors.errorString{s:"fdopen returned nil"}
        Error Trace:    capture_wrapper.go:37
	            	capture_test.go:13