### PR TITLE
Fix syscall.Dup2 availability

### DIFF
--- a/capture.go
+++ b/capture.go
@@ -8,6 +8,7 @@ import "C"
 
 import (
 	"bytes"
+	"golang.org/x/sys/unix"
 	"io"
 	"os"
 	"sync"
@@ -112,13 +113,13 @@ func CaptureWithCGo(call func()) (output []byte, err error) {
 	}
 
 	defer func() {
-		if e := syscall.Dup2(originalStdout, syscall.Stdout); e != nil {
+		if e := unix.Dup2(originalStdout, syscall.Stdout); e != nil {
 			err = e
 		}
 		if e := syscall.Close(originalStdout); e != nil {
 			err = e
 		}
-		if e := syscall.Dup2(originalStderr, syscall.Stderr); e != nil {
+		if e := unix.Dup2(originalStderr, syscall.Stderr); e != nil {
 			err = e
 		}
 		if e := syscall.Close(originalStderr); e != nil {
@@ -143,10 +144,10 @@ func CaptureWithCGo(call func()) (output []byte, err error) {
 		}
 	}()
 
-	if e := syscall.Dup2(int(w.Fd()), syscall.Stdout); e != nil {
+	if e := unix.Dup2(int(w.Fd()), syscall.Stdout); e != nil {
 		return nil, e
 	}
-	if e := syscall.Dup2(int(w.Fd()), syscall.Stderr); e != nil {
+	if e := unix.Dup2(int(w.Fd()), syscall.Stderr); e != nil {
 		return nil, e
 	}
 

--- a/capture_testwrapper.go
+++ b/capture_testwrapper.go
@@ -28,12 +28,16 @@ func testCapture(t *testing.T) {
 }
 
 func testCaptureWithCGo(t *testing.T) {
-	out, err := CaptureWithCGo(func() {
-		fmt.Println("Go")
-		C.printSomething()
-	})
+	out, err := testCaptureWithCGoWrapper()
 	assert.NoError(t, err)
 
 	assert.Contains(t, string(out), "Go")
 	assert.Contains(t, string(out), "C")
+}
+
+func testCaptureWithCGoWrapper() ([]byte, error) {
+	return CaptureWithCGo(func() {
+		fmt.Println("Go")
+		C.printSomething()
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/zimmski/osutil
 
 go 1.17
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/zimmski/osutil
+
+go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
`syscall.Dup2` is not available on all systems. Use `unix` module to shim its availability. Uses work from #17 since it covers the same code.